### PR TITLE
Add GitHub Skills activity to fix missing activity issue

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of the GitHub Certifications program to help with college applications",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
This PR adds the **GitHub Skills** activity that was announced by the principal but missing from the signup system.

## Changes Made
- Added "GitHub Skills" activity to the activities dictionary in `app.py`
- Activity details:
  - **Description**: Learn practical coding and collaboration skills through GitHub. Part of the GitHub Certifications program to help with college applications
  - **Schedule**: Wednesdays, 3:30 PM - 5:00 PM  
  - **Max Participants**: 25
  - **Current Participants**: 0 (ready for signups)

## Issue Reference
Fixes #6 🚨 Missing Activity: GitHub Skills

## Why This Is Urgent
- The principal announced this activity in assembly
- Registration deadline is end of this week
- Students need this for the GitHub Certifications program
- Important for college applications

## Testing
- [x] Activity appears in the activities list
- [x] Students can sign up using the form
- [x] Follows the same data structure as other activities

Students can now sign up for this time-sensitive activity before the registration deadline! 🎉